### PR TITLE
don't check gpg version if gpg does not exist

### DIFF
--- a/lib/Module/Signature.pm
+++ b/lib/Module/Signature.pm
@@ -143,7 +143,7 @@ sub _verify {
 }
 
 sub _has_gpg {
-    my $gpg = _which_gpg();
+    my $gpg = _which_gpg() or return;
     `$gpg --version` =~ /GnuPG.*?(\S+)\s*$/m or return;
     return $1;
 }


### PR DESCRIPTION
Hi audrey,

Module::Signature 0.69 warns more than necessarily when gpg executable is not installed. This commit should fix the issue. Thanks.
