### PR TITLE
Use SHA-256 as the default digest.

### DIFF
--- a/lib/Module/Signature.pm
+++ b/lib/Module/Signature.pm
@@ -33,7 +33,7 @@ $Timeout        = $ENV{MODULE_SIGNATURE_TIMEOUT} || 3;
 $Verbose        = $ENV{MODULE_SIGNATURE_VERBOSE} || 0;
 $KeyServer      = $ENV{MODULE_SIGNATURE_KEYSERVER} || 'pool.sks-keyservers.net';
 $KeyServerPort  = $ENV{MODULE_SIGNATURE_KEYSERVERPORT} || '11371';
-$Cipher         = $ENV{MODULE_SIGNATURE_CIPHER} || 'SHA1';
+$Cipher         = $ENV{MODULE_SIGNATURE_CIPHER} || 'SHA256';
 $Preamble       = << ".";
 This file contains message digests of all files listed in MANIFEST,
 signed via the Module::Signature module, version $VERSION.
@@ -760,15 +760,14 @@ Defaults to C<1>.
 =item $Cipher
 
 The default cipher used by the C<Digest> module to make signature
-files.  Defaults to C<SHA1>, but may be changed to other ciphers
-via the C<MODULE_SIGNATURE_CIPHER> environment variable if the SHA1
+files.  Defaults to C<SHA256>, but may be changed to other ciphers
+via the C<MODULE_SIGNATURE_CIPHER> environment variable if the SHA256
 cipher is undesirable for the user.
 
 The cipher specified in the F<SIGNATURE> file's first entry will
-be used to validate its integrity.  For C<SHA1>, the user needs
-to have any one of these four modules installed: B<Digest::SHA>,
-B<Digest::SHA1>, B<Digest::SHA::PurePerl>, or (currently nonexistent)
-B<Digest::SHA1::PurePerl>.
+be used to validate its integrity.  For C<SHA256>, the user needs
+to have either of these two modules installed: B<Digest::SHA> or
+B<Digest::SHA::PurePerl>.
 
 =item $Preamble
 


### PR DESCRIPTION
SHA-1 is presently considered weak, and most experts suggest transitioning to something better.  Use SHA-256 by default instead, as it is presently considered secure and it works well on 32-bit systems.

I considered SHA-512, which is significantly faster on 64-bit systems (and more secure), but I believe Digest::SHA requires a compiler that supports 64-bit integers for that, and as we all know Perl runs on some positively ancient systems.  Either way, changing away from Digest::SHA1 will require a non-core module for Perl before 5.9.3, but I don't consider this to be a problem given the improvement in security.

The `t/3-verify.t` test may require updating at some point, as the grep currently looks for "SHA1", but all the tests currently pass for me.
