### PR TITLE
License specification fixes

### DIFF
--- a/META.yml
+++ b/META.yml
@@ -11,7 +11,7 @@ configure_requires:
 distribution_type: module
 dynamic_config: 1
 generated_by: 'Module::Install version 1.14'
-license: cc0
+license: unrestricted
 meta-spec:
   url: http://module-build.sourceforge.net/META-spec-v1.4.html
   version: 1.4

--- a/lib/Module/Signature.pm
+++ b/lib/Module/Signature.pm
@@ -972,7 +972,10 @@ L<Dist::Zilla::Plugin::Signature>
 
 Audrey Tang E<lt>cpan@audreyt.orgE<gt>
 
-=head1 CC0 1.0 Universal
+=head1 LICENSE
+
+This work is under a B<CC0 1.0 Universal> License, although a portion
+of the documentation (as detailed above) is under the Perl license.
 
 To the extent possible under law, 唐鳳 has waived all copyright and related
 or neighboring rights to Module-Signature.

--- a/script/cpansign
+++ b/script/cpansign
@@ -85,7 +85,9 @@ L<Module::Signature>
 
 Audrey Tang E<lt>autrijus@autrijus.orgE<gt>
 
-=head1 CC0 1.0 Universal
+=head1 LICENSE
+
+This work is under the B<CC0 1.0 Universal> license.
 
 To the extent possible under law, 唐鳳 has waived all copyright and related
 or neighboring rights to Module-Signature.


### PR DESCRIPTION
- META.yml: replace invalid license string `cc0` with `unrestricted` (see `CPAN::Meta::Spec` for list of valid strings).
- POD: Use standard `LICENSE` header for clarity.

This should fix the license-related [niggles at CPANTS][cpants].

[cpants]: http://cpants.cpanauthors.org/dist/Module-Signature