### PR TITLE
fix $AUTHOR

### DIFF
--- a/lib/Module/Signature.pm
+++ b/lib/Module/Signature.pm
@@ -420,7 +420,7 @@ sub _sign_gpg {
 
     local *D;
     my $set_key = '';
-    $set_key = "--default-key $AUTHOR" if($AUTHOR);
+    $set_key = qq{--default-key "$AUTHOR"} if($AUTHOR);
     open D, "| $gpg $set_key --clearsign >> $sigfile.tmp" or die "Could not call $gpg: $!";
     print D $plaintext;
     close D;

--- a/lib/Module/Signature.pm
+++ b/lib/Module/Signature.pm
@@ -736,6 +736,12 @@ long as everything is working ok.  Defaults to false.
 The filename for a distribution's signature file.  Defaults to
 C<SIGNATURE>.
 
+=item $AUTHOR
+
+The key ID used for C<gpg> signature. If empty/null/0, C<gpg>'s configured
+default ID will be used for the signature. NOTE: this is used B<only> if
+C<gpg> is available to create the signature.
+
 =item $KeyServer
 
 The OpenPGP key server for fetching the author's public key
@@ -782,6 +788,10 @@ before the actual entries.
 B<Module::Signature> honors these environment variables:
 
 =over 4
+
+=item MODULE_SIGNATURE_AUTHOR
+
+Works like C<$AUTHOR>.
 
 =item MODULE_SIGNATURE_CIPHER
 

--- a/lib/Module/Signature.pm
+++ b/lib/Module/Signature.pm
@@ -22,7 +22,7 @@ use File::Spec;
 
 @EXPORT_OK      = (
     qw(sign verify),
-    qw($SIGNATURE $KeyServer $Cipher $Preamble),
+    qw($SIGNATURE $AUTHOR $KeyServer $Cipher $Preamble),
     (grep { /^[A-Z_]+_[A-Z_]+$/ } keys %Module::Signature::),
 );
 @ISA            = 'Exporter';


### PR DESCRIPTION
Author key IDs may contain white space (eg, 'My Name \<my.email@gmail.com\>'), and, so, $AUTHOR needs to be quoted when used.

While I was touching the code, I also added $AUTHOR to `@EXPORT_OK`. And I added some documentation about the $AUTHOR variable and $ENV{MODULE_SIGNATURE_AUTHOR} default initializer. 