### PR TITLE
Add a new .gitignore to ignore build & test byproducts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+blib/*
+t/*/*
+MYMETA.json
+MYMETA.yml
+Makefile
+pm_to_blib


### PR DESCRIPTION
It's helpful for git to have a .gitignore that lets git focus on the repository file and ignore generated byproducts.