### PR TITLE
Update docs to reflect SHA1 deprecation and SHA256 as default.

### DIFF
--- a/README
+++ b/README
@@ -45,6 +45,11 @@ DESCRIPTION
     Please also see "NOTES" about MANIFEST.SKIP issues, especially if you
     are using Module::Build or writing your own MANIFEST.SKIP.
 
+    Signatures made with Module::Signature prior to version 0.82 used the
+    SHA1 algorithm by default. SHA1 is now considered broken, and therefore
+    module authors are strongly encouraged to regenerate their SIGNATURE
+    files. Users verifying old SHA1 signature files will receive a warning.
+
 VARIABLES
     No package variables are exported by default.
 
@@ -76,15 +81,14 @@ VARIABLES
 
     $Cipher
         The default cipher used by the "Digest" module to make signature
-        files. Defaults to "SHA1", but may be changed to other ciphers via
-        the "MODULE_SIGNATURE_CIPHER" environment variable if the SHA1
+        files. Defaults to "SHA256", but may be changed to other ciphers via
+        the "MODULE_SIGNATURE_CIPHER" environment variable if the SHA256
         cipher is undesirable for the user.
 
         The cipher specified in the SIGNATURE file's first entry will be
-        used to validate its integrity. For "SHA1", the user needs to have
-        any one of these four modules installed: Digest::SHA, Digest::SHA1,
-        Digest::SHA::PurePerl, or (currently nonexistent)
-        Digest::SHA1::PurePerl.
+        used to validate its integrity. For "SHA256", the user needs to have
+        any one of these modules installed: Digest::SHA, Digest::SHA256, or
+        Digest::SHA::PurePerl.
 
     $Preamble
         The explanatory text written to newly generated SIGNATURE files
@@ -242,7 +246,7 @@ NOTES
     Truskett's Test::Signature might be a better choice.
 
 SEE ALSO
-    Digest, Digest::SHA, Digest::SHA1, Digest::SHA::PurePerl
+    Digest, Digest::SHA, Digest::SHA::PurePerl
 
     ExtUtils::Manifest, Crypt::OpenPGP, Test::Signature
 


### PR DESCRIPTION
Updating the README to reflect the change made in 0.82 with https://github.com/audreyt/module-signature/commit/4515ae5d44dbb1ac48c578f2214a64c371c3c675