### PR TITLE
prefer gpg2 when possible

### DIFF
--- a/lib/Module/Signature.pm
+++ b/lib/Module/Signature.pm
@@ -232,7 +232,7 @@ sub _which_gpg {
     # Cache it so we don't need to keep checking.
     return $which_gpg if $which_gpg;
 
-    for my $gpg_bin ('gpg', 'gpg2', 'gnupg', 'gnupg2') {
+    for my $gpg_bin ('gpg2', 'gpg', 'gnupg2', 'gnupg') {
         my $version = `$gpg_bin --version 2>&1`;
         if( $version && $version =~ /GnuPG/ ) {
             $which_gpg = $gpg_bin;


### PR DESCRIPTION
On systems that have both 'gpg' and 'gpg2', 'gpg' will sometimes be gpg
1. Prefer 'gpg2', which is more likely to be the newer version.

This can be important, because gpg 1 does not include the key
fingerprint when generating a signature, instead only including the key
id. This is true for all versions of gpg prior to 2.1.16. And gpg
versions 2.3.0 and newer only support the --auto-key-retrieve option
when the signature includes the fingerprint.